### PR TITLE
Starting point for a clap command

### DIFF
--- a/src/BaselineOfSRT2VTT/BaselineOfSRT2VTT.class.st
+++ b/src/BaselineOfSRT2VTT/BaselineOfSRT2VTT.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #BaselineOfSRT2VTT,
+	#superclass : #BaselineOf,
+	#category : #BaselineOfSRT2VTT
+}
+
+{ #category : #baselines }
+BaselineOfSRT2VTT >> baseline: spec [
+	<baseline>
+	spec for: #common do: [ spec
+		baseline: 'Clap' with: [ spec repository: 'github://cdlm/clap-st' ];
+		package: 'SRT2VTT' ]
+]

--- a/src/BaselineOfSRT2VTT/package.st
+++ b/src/BaselineOfSRT2VTT/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BaselineOfSRT2VTT }

--- a/src/SRT2VTT/SRT2VTT.class.st
+++ b/src/SRT2VTT/SRT2VTT.class.st
@@ -59,6 +59,20 @@ Class {
 	#category : #SRT2VTT
 }
 
+{ #category : #commandline }
+SRT2VTT class >> srt2vtt [
+	<commandline>
+	^ (ClapCommand withName: 'srt2vtt')
+			addPositional: ((ClapPositional withName: 'path')
+				meaning: [ :path | FileSystem disk workingDirectory resolve: path ];
+				defaultMeaning: [ FileSystem disk workingDirectory ]);
+		
+		meaning: [ :args |
+			self new
+				process: (args atName: 'path') ]
+
+]
+
 { #category : #files }
 SRT2VTT >> doNotEraseExistingVTTFiles [
 	eraseExistingVTTFiles := false
@@ -156,6 +170,13 @@ SRT2VTT >> outGotoLine [
 { #category : #files }
 SRT2VTT >> process [
 	srtFiles do: [ :each | self processFile: each ]
+]
+
+{ #category : #files }
+SRT2VTT >> process: aFileReference [
+	aFileReference isDirectory
+		ifTrue: [ self srtFilesInDirectory: aFileReference ]
+		ifFalse: [ self processFile: aFileReference ]
 ]
 
 { #category : #files }


### PR DESCRIPTION
Untested, and will not have any effect on files. Next steps would be adding a
flag to toggle `eraseExistingFiles`. The command expects a single positional
`PATH`, instead of `--file FILE` and `--folder DIR` which are overly explicit.