### PR TITLE
Problem of rewriting the vtt contents with the shorter one: solved...

### DIFF
--- a/src/SRT2VTT/SRT2VTT.class.st
+++ b/src/SRT2VTT/SRT2VTT.class.st
@@ -169,10 +169,10 @@ SRT2VTT >> processFile: aSrtFileReference [
 	| vtt rstream wstream |
 	vtt := aSrtFileReference withExtension: 'vtt'.
 	(vttFiles includes: vtt)
-		ifTrue: [ ^ self ].
+		ifTrue: [ ^ self].
 	
 	rstream := aSrtFileReference readStream.	
-	wstream := vtt writeStream.
+	wstream := FileStream forceNewFileNamed: vtt.
 	[ self in: rstream.
 	self out: wstream.
 	self go] ensure: [ rstream close. wstream close ]


### PR DESCRIPTION
... hopefully!
When we modify a srt file so that it becomes shorter and try to regenerate vtt, the new vtt contained all needed new lines and in the rest of lines keep the old contents it contained before. So, I had to remove the old vtt file  and run the tool to generate the shorter vtt.
Now, I tried to force the tool to create a new file with the same name, and to fill it with the new contenets. 
Alternatively, the old content in the same file might be deleted and the file refilled, if possible. 
Gordana